### PR TITLE
Only cache version-cache.json between runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ jobs:
         id: fetch-old-version
         uses: actions/cache@v3
         with:
-          path: .
-          key: version-cache.json
+          path: version-cache.json
+          key: version-cache
 
       - name: Deploy ACL
         if: github.event_name == 'push'


### PR DESCRIPTION
Currently, if you use the workflow as documented, then the same policy.hujson is restored on each run as the cache path is set as "."

This means new commits don't lead to changes actually being picked up or applied.

This PR changes the example workflow to only cache the `version-cache.json` file.