### PR TITLE
Only cache version-cache.json and create a new cache key on each run

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ jobs:
         id: fetch-old-version
         uses: actions/cache@v3
         with:
-          path: .
-          key: version-cache.json
+          path: version-cache.json
+          key: version-cache-${{ github.run_id }}
+          restore-keys: version-cache-
 
       - name: Deploy ACL
         if: github.event_name == 'push'


### PR DESCRIPTION
I have updated the workflow in the readme.  I have made changes to key and restore-keys in the step "Fetch old version info" in addition to path as suggested by @GingerGeek in #7.
If we do not supply a new key on each run the new hash will not be stored since github actions caches are immutable, I think.