### PR TITLE
readme: fix actions/cache usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Fetch old version info
-        id: fetch-old-version
+      - name: Fetch version-cache.json
         uses: actions/cache@v3
         with:
-          path: .
-          key: version-cache.json
+          path: ./version-cache.json
+          key: version-cache.json-${{ github.run_id }}
+          restore-keys: |
+            version-cache.json-
 
       - name: Deploy ACL
         if: github.event_name == 'push'


### PR DESCRIPTION
Explicitly name only the version-cache.json file to be cached, so as to not have the cache overwrite the policy.hujson file.

Create a new cache key for each successful run, and restore the latest key by ordered prefix match so as to avoid stale cache reads.

Fixes #7
Fixes #8
Fixes #11
