### PR TITLE
Docs: Add Section On DockerHub Authentication (rate limiting on self-hosted runners)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ automatically test and push changes to your tailnet policy file to Tailscale.
 This is a `docker` GitHub action, meaning that when it is invoked, a container image
 will be built and then run.
 
-In the scenario where you are using self-hosted runners and are being rate-limited
-by DockerHub, authenticate to DockerHub prior to invoking this action:
+In the scenario where you are using self-hosted runners and are being rate-limited by
+DockerHub (the base alpine image is from DockerHub), authenticate to DockerHub prior
+to invoking this action:
 
 ```yaml
 ...

--- a/README.md
+++ b/README.md
@@ -102,3 +102,30 @@ Then open the secrets settings for your repo and add two secrets:
 
 Once you do that, commit the changes and push them to GitHub. You will have CI
 automatically test and push changes to your tailnet policy file to Tailscale.
+
+## Note on DockerHub Rate Limiting and Self-hosted Runners
+
+This is a `docker` GitHub action, meaning that when it is invoked, a container image
+will be built and then run.
+
+In the scenario where you are using self-hosted runners and are being rate-limited
+by DockerHub, authenticate to DockerHub prior to invoking this action:
+
+```yaml
+...
+- name: Login to Docker Hub
+  uses: docker/login-action@v2
+  with:
+    username: ${{ secrets.DOCKERHUB_USERNAME }}
+    password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+- name: Deploy ACL
+  if: github.event_name == 'push'
+  id: deploy-acl
+  uses: tailscale/gitops-acl-action@v1
+  with:
+    api-key: ${{ secrets.TS_API_KEY }}
+    tailnet: ${{ secrets.TS_TAILNET }}
+    action: apply
+...
+```


### PR DESCRIPTION
This is a `docker` action, meaning that a container image is built and then run.

If you are using self-hosted runners, you may be rate-limited by DockerHub and need to authenticate (the base alpine image is from DockerHub).

```
2023-03-15T19:57:19.7869780Z ##[group]Build container for action use: '/runner/_work/_actions/tailscale/gitops-acl-action/v1/Dockerfile'.
2023-03-15T19:57:19.7898165Z ##[command]/usr/local/bin/docker build -t 60e226:9d29e60e45fc42d8a893b9e4fe1b88f9 -f "/runner/_work/_actions/tailscale/gitops-acl-action/v1/Dockerfile" "/runner/_work/_actions/tailscale/gitops-acl-action/v1"
2023-03-15T19:57:19.8830306Z #1 [internal] load .dockerignore
2023-03-15T19:57:19.8831855Z #1 sha256:6a879e6f589a58c381f1cf514e80115581cd1d586e68cd3ac5492919ed32f79d
2023-03-15T19:57:19.9917364Z #1 transferring context:
2023-03-15T19:57:20.1448501Z #1 transferring context: 2B done
2023-03-15T19:57:20.1451529Z #1 DONE 0.1s
2023-03-15T19:57:20.1454632Z 
2023-03-15T19:57:20.1454902Z #2 [internal] load build definition from Dockerfile
2023-03-15T19:57:20.1455486Z #2 sha256:b1100778b74201d5a4124d394c20c0bf8debdc3b0307e6f09c74959e45343a73
2023-03-15T19:57:20.1455990Z #2 transferring dockerfile: 303B done
2023-03-15T19:57:20.1456517Z #2 DONE 0.1s
2023-03-15T19:57:20.1456852Z 
2023-03-15T19:57:20.1457132Z #4 [internal] load metadata for docker.io/library/golang:1.18.4-alpine3.16
2023-03-15T19:57:20.1457746Z #4 sha256:f08e3c9d4e7935cd41002ed0ebee3bcb6dc6be72eb413c1bf63cb2f6a031af7e
2023-03-15T19:57:20.4006646Z #4 ERROR: failed to copy: httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/library/golang/manifests/sha256:e0585a7a957c33f63ff0f4e3ac914c67f87a13bb359e08e39e1b55cfe0952d70: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

This simply adds a section warning about this scenario and telling users what to do prior to invoking the action, if they are affected.