### PR TITLE
harden image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM golang:1.18.4-alpine3.16 AS build
-
+FROM cgr.dev/chainguard/go:latest AS build
+WORKDIR /go
+ENV GOBIN=/go/bin
 RUN go install tailscale.com/cmd/gitops-pusher@gitops-1.30.0
 
-FROM alpine:3.16
+FROM cgr.dev/chainguard/wolfi-base
 
 COPY --from=build /go/bin/gitops-pusher /usr/local/bin/gitops-pusher
 COPY ./entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
```bash
trivy i gitops-acl-action --ignore-unfixed -s=CRITICAL,HIGH,MEDIUM,LOW
2023-04-27T16:13:20.859-0700	INFO	Vulnerability scanning is enabled
2023-04-27T16:13:20.859-0700	INFO	Secret scanning is enabled
2023-04-27T16:13:20.859-0700	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-04-27T16:13:20.859-0700	INFO	Please see also https://aquasecurity.github.io/trivy/v0.38/docs/secret/scanning/#recommendation for faster secret detection
2023-04-27T16:13:21.190-0700	INFO	Detected OS: wolfi
2023-04-27T16:13:21.190-0700	INFO	Detecting Wolfi vulnerabilities...
2023-04-27T16:13:21.193-0700	INFO	Number of language-specific files: 1
2023-04-27T16:13:21.193-0700	INFO	Detecting gobinary vulnerabilities...

gitops-acl-action (wolfi 20230201)

Total: 0 (LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```