### PR TITLE
bump actions/setup-go to v5.0.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,14 +29,13 @@ runs:
       run: |
         echo "::error title=⛔ error hint::API Key or OAuth secret must be specified. Maybe you need to populate it in the Secrets for your workflow, see more in https://docs.github.com/en/actions/security-guides/encrypted-secrets and https://tailscale.com/s/oauth-clients"
         exit 1
-    - uses: actions/setup-go@v4.0.0
+    - uses: actions/setup-go@v5.0.0
       with:
         go-version: 1.21.6
     - shell: bash
       env:
         GOBIN: /usr/local/bin/
       run: go install tailscale.com/cmd/gitops-pusher@gitops-1.58.2
-
     - shell: bash
       env:
         TS_API_KEY: "${{ inputs.api-key }}"


### PR DESCRIPTION
This resolves the node.js 16 deprecation warning when running.