### PR TITLE
Disable setup-go's cache

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,7 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version: 1.22.1
+        cache: false
 
     - name: Gitops pusher
       shell: bash


### PR DESCRIPTION
`setup-go` attempts to find and hash `go.sum` files to build a cache key. Since we don't use `go.sum` files, this fails and `setup-go` continues with a warning like

> Restore cache failed: Dependencies file is not found in `...`. Supported file pattern: `go.sum`

which is annoying. We can prevent it from printing by disabling the cache.

See: [actions/setup-go/docs/adrs/0000-caching-dependencies.md](https://github.com/actions/setup-go/blob/6c1fd22b67f7a7c42ad9a45c0f4197434035e429/docs/adrs/0000-caching-dependencies.md#decision).