### PR TITLE
action.yml use go run to avoid PATH issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,10 +38,6 @@ runs:
     - uses: actions/setup-go@v4.0.0
       with:
         go-version: 1.21.6
-    - shell: bash
-      env:
-        GOBIN: /usr/local/bin/
-      run: go install tailscale.com/cmd/gitops-pusher@gitops-1.58.2
 
     - name: Gitops pusher (API Key)
       if: ${{ inputs['api-key'] != '' }}
@@ -49,7 +45,7 @@ runs:
       env:
         TS_API_KEY: "${{ inputs.api-key }}"
         TS_TAILNET: "${{ inputs.tailnet }}"
-      run: gitops-pusher "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
+      run: go run tailscale.com/cmd/gitops-pusher@gitops-1.58.2 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
 
     - name: Gitops pusher (OAuth)
       if: ${{ inputs['oauth-secret'] != '' }}
@@ -58,4 +54,4 @@ runs:
         TS_OAUTH_ID: "${{ inputs.oauth-client-id }}"
         TS_OAUTH_SECRET: "${{ inputs.oauth-secret }}"
         TS_TAILNET: "${{ inputs.tailnet }}"
-      run: gitops-pusher "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
+      run: go run tailscale.com/cmd/gitops-pusher@gitops-1.58.2 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"


### PR DESCRIPTION
Self-hosted runners sometimes can't write the built binary to /usr/local/bin, so just use `go run` instead.

Updates #28