### PR TITLE
action.yml: recombine gitops-pusher calls

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,21 +37,15 @@ runs:
         exit 1
     - uses: actions/setup-go@v4.0.0
       with:
-        go-version: 1.21.6
+        go-version: 1.22.1
 
-    - name: Gitops pusher (API Key)
-      if: ${{ inputs['api-key'] != '' }}
+    - name: Gitops pusher
       shell: bash
       env:
-        TS_API_KEY: "${{ inputs.api-key }}"
-        TS_TAILNET: "${{ inputs.tailnet }}"
-      run: go run tailscale.com/cmd/gitops-pusher@gitops-1.58.2 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
-
-    - name: Gitops pusher (OAuth)
-      if: ${{ inputs['oauth-secret'] != '' }}
-      shell: bash
-      env:
+        # gitops-pusher will use OAUTH_ID and OAUTH_SECRET if non-empty,
+        # otherwise it will use API_KEY.
         TS_OAUTH_ID: "${{ inputs.oauth-client-id }}"
         TS_OAUTH_SECRET: "${{ inputs.oauth-secret }}"
+        TS_API_KEY: "${{ inputs.api-key }}"
         TS_TAILNET: "${{ inputs.tailnet }}"
-      run: go run tailscale.com/cmd/gitops-pusher@gitops-1.58.2 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
+      run: go run tailscale.com/cmd/gitops-pusher@v1.62.0 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"


### PR DESCRIPTION
We previously split the gitops-pusher steps based on which auth variables were set due to a bug in the gitops-pusher tool itself.  That as fixed in tailscale/tailscale#11025, so we can now recombine these.

Update to latest tagged version of tailscale to pull in the fix, and bump the go version while we're at it.