### PR TITLE
action: bump version of setup-go action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ runs:
       run: |
         echo "::error title=⛔ error hint::only one of API Key or OAuth secret should be specified.
         exit 1
-    - uses: actions/setup-go@v4.0.0
+    - uses: actions/setup-go@v5
       with:
         go-version: 1.22.1
 


### PR DESCRIPTION
Most notably, this moves from node16 to node20.

Manually tested on a private test repo.