### PR TITLE
README.md,action.yml: bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Fetch version-cache.json
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ./version-cache.json
           key: version-cache.json-${{ github.run_id }}

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         exit 1
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.22.1
+        go-version: 1.22.4
         cache: false
 
     - name: Gitops pusher
@@ -49,4 +49,4 @@ runs:
         TS_OAUTH_SECRET: "${{ inputs.oauth-secret }}"
         TS_API_KEY: "${{ inputs.api-key }}"
         TS_TAILNET: "${{ inputs.tailnet }}"
-      run: go run tailscale.com/cmd/gitops-pusher@v1.62.0 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
+      run: go run tailscale.com/cmd/gitops-pusher@v1.66.4 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"


### PR DESCRIPTION
This version bump is pretty much a no-op, I just wanted to bump things before cutting a new tag.

I have tested (using my fork of this repo) that an action with changes from this PR succeeds. (Additionally, I have tested that the cache errors that were reported in #41 and #36 are not present in build from main).

Once this PR merges, I will cut a new tag and create a new Github release