### PR TITLE
README: add a note about versioning releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,17 @@ Then open the secrets settings for your repo and add two secrets:
 
 Once you do that, commit the changes and push them to GitHub. You will have CI
 automatically test and push changes to your tailnet policy file to Tailscale.
+
+## Developer guide
+
+### Release process
+
+To create a new minor or patch release:
+
+- push the new tag to the main branch
+
+- create a new GitHub release with a description of the changes in this release
+
+- repush the latest major release tag to point at the new latest release.
+For example, if you are creating a `v1.3.1` release, you want to additionally tag it with `v1` tag.
+This approach follows the [official GitHub actions versioning guidelines](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management).


### PR DESCRIPTION
We had a user complain that the example workflow in the Readme, does not pull in the latest version.

In the absence of a mechanism to specify the latest version with the actions syntax (?) I'm just bumping it to v1.3.0 by hand.
(Not sure whether this is what we usually do- if we usually retag the main branch to v1, happy to do that and update Readme to document that process in this PR instead)