### PR TITLE
Bump Go version to minimum v1.23.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         exit 1
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.22.4
+        go-version: 1.23.1
         cache: false
 
     - name: Gitops pusher

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         exit 1
     - uses: actions/setup-go@v5
       with:
-        go-version: 1.23.1
+        go-version: '>=1.23.1'
         cache: false
 
     - name: Gitops pusher


### PR DESCRIPTION
As required by Tailscale v1.74.0

Fixes https://github.com/tailscale/gitops-acl-action/issues/51