### PR TITLE
Set cache:true for actions/setup-go

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version: 1.22.4
-        cache: false
+        cache: true
 
     - name: Gitops pusher
       shell: bash


### PR DESCRIPTION
The gitops workflow for syncing the Tailscale ACL currently does not cache the golang setup step. Enabling caching will drastically speed up sync times. 