### PR TITLE
action.yml: update dependencies

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,9 @@ runs:
       run: |
         echo "::error title=⛔ error hint::only one of API Key or OAuth secret should be specified.
         exit 1
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
       with:
-        go-version: 1.22.4
+        go-version: 1.25.5
         cache: false
 
     - name: Gitops pusher
@@ -49,4 +49,4 @@ runs:
         TS_OAUTH_SECRET: "${{ inputs.oauth-secret }}"
         TS_API_KEY: "${{ inputs.api-key }}"
         TS_TAILNET: "${{ inputs.tailnet }}"
-      run: go run tailscale.com/cmd/gitops-pusher@66aa77416744037baec93206ae212012a2314f83 "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"
+      run: go run tailscale.com/cmd/gitops-pusher@2078eb56f3ca310821aae3fa140aa3b0d3bda2dc "--policy-file=${{ inputs.policy-file }}" "${{ inputs.action }}"


### PR DESCRIPTION
Update actions/setup-go to its latest version and pin to this version.

Use go 1.25.5 in the aforementioned action (latest at the time of writing and to match v1.92.1 of tailscale).

Update pinned gitops-pusher sha to v1.92.1 in tailscale.

Fixes https://github.com/tailscale/gitops-acl-action/issues/51 
Fixes https://github.com/tailscale/gitops-acl-action/issues/66