### PR TITLE
Fix link to federated identity documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
           action: test
 ```
 
-Generate a new federated identity. See [here](https://login.tailscale.com/admin/settings/keys) for instructions.
+Generate a new federated identity. See [here](https://tailscale.com/docs/integrations/github/github-action) for instructions.
 
 Then open the secrets settings for your repo and add two secrets:
 


### PR DESCRIPTION
Updated link for federated identity instructions. It was linked to our Keys page, and not the GitHub Actions page in our docs that go into detail on the requirements for the identity.